### PR TITLE
Implement plain text message sending

### DIFF
--- a/src/messageschannel.cpp
+++ b/src/messageschannel.cpp
@@ -29,7 +29,9 @@
 // QMatrixClient
 #include <connection.h>
 #include <room.h>
+#include <settings.h>
 #include <user.h>
+#include <events/roommemberevent.h>
 
 MatrixMessagesChannel::MatrixMessagesChannel(MatrixConnection *connection, QMatrixClient::Room *room, Tp::BaseChannel *baseChannel)
     : Tp::BaseChannelTextType(baseChannel),
@@ -130,6 +132,11 @@ MatrixMessagesChannelPtr MatrixMessagesChannel::create(MatrixConnection *connect
 
 QString MatrixMessagesChannel::sendMessageCallback(const Tp::MessagePartList &messageParts, uint flags, Tp::DBusError *error)
 {
+    if (!m_room) {
+        // TODO: error?
+        qDebug() << Q_FUNC_INFO;
+        return QString();
+    }
     QString content;
     foreach (const Tp::MessagePart &part, messageParts) {
         if (part.contains(QStringLiteral("content-type"))

--- a/src/messageschannel.cpp
+++ b/src/messageschannel.cpp
@@ -29,9 +29,7 @@
 // QMatrixClient
 #include <connection.h>
 #include <room.h>
-#include <settings.h>
 #include <user.h>
-#include <events/roommemberevent.h>
 
 MatrixMessagesChannel::MatrixMessagesChannel(MatrixConnection *connection, QMatrixClient::Room *room, Tp::BaseChannel *baseChannel)
     : Tp::BaseChannelTextType(baseChannel),

--- a/src/messageschannel.hpp
+++ b/src/messageschannel.hpp
@@ -71,6 +71,8 @@ public:
 private:
     MatrixMessagesChannel(MatrixConnection *connection, QMatrixClient::Room *room, Tp::BaseChannel *baseChannel);
 
+    void onPendingEventChanged(int pendingEventIndex);
+
     MatrixConnection *m_connection = nullptr;
     QMatrixClient::Room *m_room = nullptr;
 


### PR DESCRIPTION
Fixing #5.

Implementation notes:

1. While working with `Tp::HandleTypeContact`, I could probably miss some additional initialization (not sure)
2. According to [`QMatrixClient::doInDirectChat`](https://github.com/QMatrixClient/libqmatrixclient/blob/master/lib/connection.h#L440), the method could be async and it's not clear for me yet, could `MatrixMessagesChannel::sendMessageCallback` be executed earlier than `m_room` initialization. (that's why I'm checking for `m_room` and the beginning of the `MatrixMessagesChannel::sendMessageCallback`
3. `MatrixMessagesChannel::sendMessageCallback`: `content` getting from `messageParts` is based on similar [telepathy-nonsense](https://github.com/TelepathyIM/telepathy-nonsense/blob/master/textchannel.cc#L124) and [telepathy-morse](https://github.com/TelepathyIM/telepathy-morse/blob/master/textchannel.cpp#L150) implementation.
4. `MatrixMessagesChannel::sendMessageCallback`: `txnId` getting and `postPlainText` sending is based on `QMCTest::sendMessage` from [libqmatrixclient](https://github.com/QMatrixClient/libqmatrixclient/blob/master/examples/qmc-example.cpp#L151).

For initial version, looks like the messages are sending okay for me.
