### PR TITLE
Basic support for room name/topic

### DIFF
--- a/src/messageschannel.hpp
+++ b/src/messageschannel.hpp
@@ -75,6 +75,8 @@ private:
     void sendDeliveryReport(Tp::DeliveryStatus tpDeliveryStatus, const QString &deliveryToken);
     void onPendingEventChanged(int pendingEventIndex);
     void onReadMarkerForUserMoved(Quotient::User* user, const QString &fromEventId, const QString &toEventId);
+    void onDisplayNameChanged(Quotient::Room *room, const QString &oldName);
+    void onTopicChanged();
     void onTypingChanged();
     void reactivateLocalTyping();
     void sendChatStateNotification(uint state);


### PR DESCRIPTION
* MessageChannel now implements BaseChannelRoomConfigInterface and sets
  the description and title to the Matrix topic and displayName
respectively. It also updates those when they are changed.

I'm not sure if I should also create the roomConfigIface for 1 to 1 chats. The main reason why I'm doing this at this moment is to allow the room name and topic to be changeable, so it doesn't stay the room id forever.